### PR TITLE
fix: update condition for rendering MeshPreviewCenterPoint based on u…

### DIFF
--- a/src/components/mesh/preview/mesh-preview-center-point.tsx
+++ b/src/components/mesh/preview/mesh-preview-center-point.tsx
@@ -26,7 +26,7 @@ export const MeshPreviewCenterPoint = ({ canvasRef, contentRef }: Props) => {
   const { frame } = useFrameContext();
   const { canvas } = useMeshDrawing({ canvasRef });
 
-  if (!(ui.showVertices && frame?.width && frame?.height)) {
+  if (!(ui.showCenters && frame?.width && frame?.height)) {
     return null;
   }
 


### PR DESCRIPTION
…i.showCenters

- Changed the condition in MeshPreviewCenterPoint to check for ui.showCenters instead of ui.showVertices, ensuring the correct display of center points based on the updated UI settings.
- Ensured consistent use of inferred types and added comments for clarity throughout the updated component.